### PR TITLE
Upgrade llvmlite

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - python
     - pip
     - setuptools
-    - llvmlite >=0.29.0
+    - llvmlite >=0.30.0
     - numpy
     - tbb-devel >=2018.0.5  # [linux]
     - enum34                # [py2k]
@@ -44,7 +44,7 @@ requirements:
     - python
     - {{ pin_compatible('llvmlite', max_pin='x.x') }}
     - {{ pin_compatible('numpy') }}
-    - llvmlite >=0.29.0
+    - llvmlite >=0.30.0
     - enum34          # [py2k]
     - singledispatch  # [py2k]
     - funcsigs        # [py2k]
@@ -107,9 +107,9 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: NumPy aware dynamic Python compiler using LLVM
-  description: | 
-    Numba is an Open Source NumPy-aware optimizing compiler for Python 
-    sponsored by Anaconda, Inc. It uses the remarkable LLVM compiler 
+  description: |
+    Numba is an Open Source NumPy-aware optimizing compiler for Python
+    sponsored by Anaconda, Inc. It uses the remarkable LLVM compiler
     infrastructure to compile Python syntax to machine code."
   doc_url: http://numba.pydata.org/
   dev_url: https://github.com/numba/numba


### PR DESCRIPTION
This PR upgrades llvmite into the current auto generated PR for numba. Tests are currently failing with:
https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=79444
```
import: 'numba'
Traceback (most recent call last):
  File "/home/conda/feedstock_root/build_artifacts/numba_1570663065622/test_tmp/run_test.py", line 2, in <module>
    import numba
  File "/home/conda/feedstock_root/build_artifacts/numba_1570663065622/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/lib/python2.7/site-packages/numba/__init__.py", line 178, in <module>
    _ensure_llvm()
  File "/home/conda/feedstock_root/build_artifacts/numba_1570663065622/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/lib/python2.7/site-packages/numba/__init__.py", line 100, in _ensure_llvm
    raise ImportError(msg)
ImportError: Numba requires at least version 0.30.0 of llvmlite.
Installed version is 0.29.0.
Please update llvmlite.
```